### PR TITLE
Update way in which the script path is obtained

### DIFF
--- a/build_idjl_gcc_vxworks.sh
+++ b/build_idjl_gcc_vxworks.sh
@@ -12,8 +12,7 @@ trap 'echo FAILED COMMAND: $previous_command' EXIT
 # Based on http://preshing.com/20141119/how-to-build-a-gcc-cross-compiler
 #-------------------------------------------------------------------------------------------
 
-SCRIPT=`realpath $0`
-export SCRIPTPATH=`dirname $SCRIPT`
+export SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export INSTALL_PATH=${SCRIPTPATH}/install
 export TARGET=i586-wrs-vxworks
 export CONFIGURATION_OPTIONS="--disable-multilib --disable-threads --disable-libssp --disable-libquadmath --disable-libquadmath-support --enable-libstdcxx --disable-libstdcxx-pch --disable-libitm --disable-libcc1 --with-native-system-header-dir=${SCRIPTPATH}/wrs-vxworks-headers/sys-include"

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,6 @@
 #! /bin/bash
 
-SCRIPT=`realpath $0`
-export SCRIPTPATH=`dirname $SCRIPT`
+export SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # Prepend the variables so if there is any conflict 
 # the local one will be used

--- a/setup.sh.in
+++ b/setup.sh.in
@@ -1,7 +1,6 @@
 #! /bin/bash
 
-SCRIPT=`realpath $0`
-export SCRIPTPATH=`dirname $SCRIPT`
+export SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # Prepend the variables so if there is any conflict 
 # the local one will be used


### PR DESCRIPTION
realpath does not work correctly when the script is sourced instead  of executed,
see https://stackoverflow.com/questions/59895/get-the-source-directory-of-a-bash-script-from-within-the-script-itself