### PR TITLE
Ensure that gettimeofday declaration works fine also in C++

### DIFF
--- a/sys_time.h
+++ b/sys_time.h
@@ -7,6 +7,6 @@
 
 struct timeval; 
 
-int gettimeofday(struct timeval *restrict tp, void *restrict tzp); 
+int gettimeofday(struct timeval * tp, void * tzp); 
 
 #endif


### PR DESCRIPTION
`restrict` is not a keyword directly supported in C++ compiler, and the added  benefit is not worth to have some logic to just enable it when a C compiler is used. 

See https://en.wikipedia.org/wiki/Restrict for more details.

