### PR TITLE
Include `sys/times.h` instead  of forward declare struct timeval

### DIFF
--- a/sys_time.h
+++ b/sys_time.h
@@ -5,7 +5,7 @@
 // available in VxWorks 6.3, the version for which public headers are available 
 // Definition from http://pubs.opengroup.org/onlinepubs/009695399/functions/gettimeofday.html
 
-struct timeval; 
+#include <sys/times.h>
 
 int gettimeofday(struct timeval * tp, void * tzp); 
 


### PR DESCRIPTION
I checked again the Windows 0.3.0, and the version that is working fine is actually this one.