### PR TITLE
Fix path in setup.sh.in

### DIFF
--- a/setup.sh.in
+++ b/setup.sh.in
@@ -4,7 +4,7 @@ export SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && p
 
 # Prepend the variables so if there is any conflict 
 # the local one will be used
-export PATH=${SCRIPTPATH}/install/bin:$PATH
-export CMAKE_PREFIX_PATH=${SCRIPTPATH}/install:$CMAKE_PREFIX_PATH
-export LD_LIBRARY_PATH=${SCRIPTPATH}/install/lib:$LD_LIBRARY_PATH
+export PATH=${SCRIPTPATH}/bin:$PATH
+export CMAKE_PREFIX_PATH=${SCRIPTPATH}:$CMAKE_PREFIX_PATH
+export LD_LIBRARY_PATH=${SCRIPTPATH}/lib:$LD_LIBRARY_PATH
 export WIND_BASE=${SCRIPTPATH}/wrs-vxworks-headers/wind_base


### PR DESCRIPTION
This files is installed in the release archive, and there there is no `install` directory.